### PR TITLE
Move the auth key variable to proper location

### DIFF
--- a/packages/installCombinators.sh
+++ b/packages/installCombinators.sh
@@ -3,9 +3,6 @@
 # use the command line interface to install standard actions deployed
 # automatically.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installGit.sh
+++ b/packages/installGit.sh
@@ -2,9 +2,6 @@
 #
 # use the command line interface to install Git package.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installSlack.sh
+++ b/packages/installSlack.sh
@@ -2,9 +2,6 @@
 #
 # use the command line interface to install Slack package.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installSystem.sh
+++ b/packages/installSystem.sh
@@ -3,9 +3,6 @@
 # use the command line interface to install standard actions deployed
 # automatically.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installWatson.sh
+++ b/packages/installWatson.sh
@@ -2,9 +2,6 @@
 #
 # use the command line interface to install Watson package.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installWeather.sh
+++ b/packages/installWeather.sh
@@ -2,9 +2,6 @@
 #
 # use the command line interface to install Weather.com package.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/installWebSocket.sh
+++ b/packages/installWebSocket.sh
@@ -2,9 +2,6 @@
 #
 # use the command line interface to install websocket package.
 #
-: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
-AUTH_KEY=$WHISK_SYSTEM_AUTH
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PACKAGE_HOME=$SCRIPTDIR
 source "$PACKAGE_HOME/util.sh"

--- a/packages/util.sh
+++ b/packages/util.sh
@@ -8,6 +8,9 @@
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 OPENWHISK_HOME=${OPENWHISK_HOME:-$SCRIPTDIR/../../openwhisk}
 
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
 : ${WHISK_API_HOST:?"WHISK_API_HOST must be set and non-empty"}
 EDGE_HOST=$WHISK_API_HOST
 


### PR DESCRIPTION
the `AUTH_KEY` variable is defined repeatedly on `installCombinators.sh`, `installGit.sh` and so on.
So it is necessary to move it to `util.sh` 