### PR TITLE
Update README for actual installCatalog.sh location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for information about how to browse the catalog by using the command line tool.
 We should be able to run the script installCatalog.sh to install the catalog like:
 
 ```
-./installCatalog.sh [catalog_auth_key] [api_host]
+./packages/installCatalog.sh [catalog_auth_key] [api_host]
 ```
 
 The first argument `catalog_auth_key`, defines the secret key used to authenticate the openwhisk


### PR DESCRIPTION
The README references the root `./installCatalog.sh` when the shell script is actually in the `packages` subfolder.