### PR TITLE
Use websocket.org for WebSocket tests

### DIFF
--- a/tests/src/test/scala/packages/websocket/WebSocketTests.scala
+++ b/tests/src/test/scala/packages/websocket/WebSocketTests.scala
@@ -48,7 +48,7 @@ class WebSocketTests extends TestHelpers with WskTestHelpers with BeforeAndAfter
   /**
    * This test requires a websocket server running on the given URI.
    */
-  val serverURI: URI = new URI(s"ws://$websocketHost:$websocketPort")
+  val serverURI: URI = new URI("ws://echo.websocket.org")
 
   it should "Use the websocket action to send a payload" in {
     val uniquePayload = s"The cow says ${System.currentTimeMillis()}".toJson
@@ -90,68 +90,4 @@ class WebSocketTests extends TestHelpers with WskTestHelpers with BeforeAndAfter
     }
   }
 
-  override def beforeAll() {
-
-    val websocketServer =
-      """
-         | const WebSocket = require("ws");
-         | const wss = new WebSocket.Server({ port: 8080 });
-         | wss.on("connection", function connection(ws) {
-         |  ws.on("message", function incoming(message) {
-         |    ws.send(message);
-         |  });
-         | });
-         """.replace("\r", "").stripMargin.lines.mkString
-    TestUtils.runCmd(TestUtils.DONTCARE_EXIT, new File("."), "docker", "kill", containerName)
-    TestUtils.runCmd(TestUtils.DONTCARE_EXIT, new File("."), "docker", "rm", containerName)
-    TestUtils.runCmd(
-      0,
-      new File("."),
-      "docker",
-      "run",
-      "-d",
-      "-p",
-      "20002:8080",
-      "--name",
-      containerName,
-      "node",
-      "sh",
-      "-c",
-      s"npm install ws; echo '$websocketServer' | node")
-    sleepUntilContainerRunning()
-
-  }
-
-  def sleepUntilContainerRunning() {
-    var counter = 12
-    var running = false
-    do {
-      counter = counter - 1
-      val isdb2Running = TestUtils
-        .runCmd(
-          TestUtils.DONTCARE_EXIT,
-          new File("."),
-          "docker",
-          "exec",
-          "-t",
-          containerName,
-          "curl",
-          "http://localhost:8080",
-          "--connect-timeout",
-          "5")
-
-      if (isdb2Running.exitCode != 0) {
-        println("sleeping 5 seconds to wait for websocket server")
-        Thread.sleep(5000)
-      } else {
-        running = true
-      }
-    } while (counter > 0 && !running)
-    running shouldBe true
-  }
-
-  override def afterAll() {
-    TestUtils.runCmd(TestUtils.DONTCARE_EXIT, new File("."), "docker", "kill", containerName)
-    TestUtils.runCmd(TestUtils.DONTCARE_EXIT, new File("."), "docker", "rm", containerName)
-  }
 }

--- a/tests/src/test/scala/packages/websocket/WebSocketTests.scala
+++ b/tests/src/test/scala/packages/websocket/WebSocketTests.scala
@@ -17,7 +17,6 @@
 
 package packages.websocket
 
-import java.io.File
 import java.net.URI
 
 import scala.concurrent.duration.DurationInt
@@ -36,12 +35,6 @@ class WebSocketTests extends TestHelpers with WskTestHelpers with BeforeAndAfter
   val wsk = new Wsk()
 
   val websocketSendAction = "/whisk.system/websocket/send"
-
-  val containerName = "websocketServerOW"
-  val userDir: String = System.getProperty("user.dir")
-  val websocketDir: String = userDir + "/dat/websocket"
-  val websocketHost: String = wskprops.apihost
-  val websocketPort = "20002"
 
   behavior of "Websocket action"
 


### PR DESCRIPTION
Instead of setting up a WebSocket server for the WebSocket test suite, use `websocket.org` instead.