### PR TITLE
update weather package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ in the format of IP or hostname. The third argument `cli_path` is the full path 
 | --- | --- |
 | [/whisk.system/github](./packages/github/README.md) | offers a convenient way to use the [GitHub APIs](https://developer.github.com/). |
 | [/whisk.system/slack](./packages/slack/README.md) | offers a convenient way to use the [Slack APIs](https://api.slack.com/). |
-| [/whisk.system/weather](./packages/weather/README.md) | Services from the Weather Company Data for IBM Bluemix API|
+| [/whisk.system/weather](./packages/weather/README.md) | Services from the Weather Company Data for IBM Cloud API|
 | [/whisk.system/websocket](./packages/websocket/README.md) | Package to send messages to Web Socket server|
 
 <!--

--- a/packages/installWeather.sh
+++ b/packages/installWeather.sh
@@ -25,7 +25,7 @@ echo Installing Weather package.
 
 createPackage weather \
     -p bluemixServiceName "weatherinsights" \
-    -a description "Services from the Weather Company Data for IBM Bluemix" \
+    -a description "Services from the Weather Company Data for IBM Cloud" \
     -a parameters '[{"name":"username", "required":false,"bindTime":true}, {"name":"password", "required":false, "type":"password","bindTime":true}]'
 
 waitForAll

--- a/packages/weather/README.md
+++ b/packages/weather/README.md
@@ -19,60 +19,33 @@
 
 ## Using the Weather package
 
-The `/whisk.system/weather` package offers a convenient way to call the Weather Company Data for IBM Bluemix API.
+The `/whisk.system/weather` package offers a convenient way to call the Weather Company Data for IBM Cloud API.
 
 The package includes the following action.
 
 | Entity | Type | Parameters | Description |
 | --- | --- | --- | --- |
-| `/whisk.system/weather` | package | username, password | Services from the Weather Company Data for IBM Bluemix API  |
+| `/whisk.system/weather` | package | username, password | Services from the Weather Company Data for IBM Cloud API  |
 | `/whisk.system/weather/forecast` | action | latitude, longitude, timePeriod | forecast for specified time period|
 
-Creating a package binding with the `username` and `password` values is suggested. This way, you don't need to specify the credentials every time you invoke the actions in the package.
+Creating a package binding with the `username`, `password` and `host` values is suggested. This way, you don't need to specify the credentials every time you invoke the actions in the package.
 
-## Setting up the Weather package in Bluemix
+## Setting up the Weather package
 
-If you're using OpenWhisk from Bluemix, OpenWhisk automatically creates package bindings for your Bluemix Weather service instances.
+1. Create a Weather Company Data service instance in your IBM Cloud [dashboard](https://cloud.ibm.com).
 
-1. Create a Weather Company Data service instance in your Bluemix [dashboard](http://console.ng.Bluemix.net).
-
-  Be sure to remember the name of the service instance and the Bluemix organization and space you're in.
-
-2. Refresh the packages in your namespace. The refresh automatically creates a package binding for the Weather Company Data service instance that you created.
+2. Create a package binding that is configured for your Weather Company Data service using the username, password, and host from its service credentials.
 
   ```
-  wsk package refresh
+  wsk package bind /whisk.system/weather myWeather -p username MYUSERNAME -p password MYPASSWORD -p host HOST
   ```
-  ```
-  created bindings:
-  Bluemix_Weather_Company_Data_Credentials-1
-  ```
-  ```
-  wsk package list
-  ```
-  ```
-  packages
-  /myBluemixOrg_myBluemixSpace/Weather Bluemix_Weather_Company_Data_Credentials-1 private
-  ```
-
-
-## Setting up a Weather package outside Bluemix
-
-If you're not using OpenWhisk in Bluemix or if you want to set up your Weather Company Data service outside of Bluemix, you must manually create a package binding for your WWeather Company Data service. You need the Weather Company Data service user name, and password.
-
-- Create a package binding that is configured for your Weather Company Data service.
-
-  ```
-  wsk package bind /whisk.system/weather myWeather -p username MYUSERNAME -p password MYPASSWORD
-  ```
-
 
 ## Getting a weather forecast for a location
 
 The `/whisk.system/weather/forecast` action returns a weather forecast for a location by calling an API from The Weather Company. The parameters are as follows:
 
-- `username`: Username for The Weather Company Data for IBM Bluemix that is entitled to invoke the forecast API.
-- `password`: Password for The Weather Company Data for IBM Bluemix that is entitled to invoke the forecast API.
+- `username`: Username for The Weather Company Data for IBM Cloud that is entitled to invoke the forecast API.
+- `password`: Password for The Weather Company Data for IBM Cloud that is entitled to invoke the forecast API.
 - `latitude`: The latitude coordinate of the location.
 - `longitude`: The longitude coordinate of the location.
 - `timePeriod`: Time period for the forecast. Valid options are:
@@ -80,10 +53,10 @@ The `/whisk.system/weather/forecast` action returns a weather forecast for a loc
   - `48hour` - Returns an hourly 2-day forecast
   - `current` - Returns the current weather conditions
   - `timeseries` - Returns both the current observations and up to 24 hours of past observations, from the current date and time.
-- `host`: Host for The Weather Company Data for IBM Bluemix
+- `host`: Host for The Weather Company Data for IBM Cloud
 
 
-The following is an example of creating a package binding and then getting a 10-day forecast.
+The following is an example of getting a 10-day forecast.
 
 - Invoke the `forecast` action in your package binding to get the weather forecast.
 

--- a/packages/weather/manifest.yaml
+++ b/packages/weather/manifest.yaml
@@ -22,7 +22,7 @@ project:
             version: 0.0.1
             public: true
             annotations:
-                description: "Services from the Weather Company Data for IBM Bluemix"
+                description: "Services from the Weather Company Data for IBM Cloud"
                 parameters: [
                     {
                         "name": "username",


### PR DESCRIPTION
1. Update vendor branding Bluemix ==> IBM Cloud
2. Update package binding instructions; IBM docs no longer
   recommend `package refresh`, so we can have uniform
   instructions to instantiate the package explicitly with
   username, password, and host info.