### PR TITLE
Use needle to replace request

### DIFF
--- a/packages/slack/post.js
+++ b/packages/slack/post.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-var request = require('request');
+const needle = require('needle');
 
 /**
  * Action to post to slack
@@ -76,10 +76,7 @@ function main(params) {
     }
 
     var promise = new Promise(function (resolve, reject) {
-        request.post({
-            url: params.url,
-            formData: body
-        }, function (err, res, body) {
+        needle.post(params.url, body, function (err, res, body) {
             if (err) {
                 console.log('error: ', err, body);
                 reject(err);

--- a/packages/weather/forecast.js
+++ b/packages/weather/forecast.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-var request = require('request');
+const needle = require('needle');
 
 /**
  * Get hourly weather forecast for a lat/long from the Weather API service.
@@ -34,15 +34,15 @@ function main(params) {
     var username = params.username;
     var password = params.password;
     var lat = params.latitude || '0';
-    var lon = params.longitude ||  '0';
+    var lon = params.longitude || '0';
     var language = params.language || 'en-US';
     var units = params.units || 'm';
     var timePeriod = params.timePeriod || '10day';
     var host = params.host || 'twcservice.mybluemix.net';
     var url = 'https://' + host + '/api/weather/v1/geocode/' + lat + '/' + lon;
-    var qs = {language: language, units: units};
+    var qs = { language: language, units: units };
 
-    switch(timePeriod) {
+    switch (timePeriod) {
         case '48hour':
             url += '/forecast/hourly/48hour.json';
             break;
@@ -60,13 +60,8 @@ function main(params) {
 
     console.log('url:', url);
 
-    var promise = new Promise(function(resolve, reject) {
-        request({
-            url: url,
-            qs: qs,
-            auth: {username: username, password: password},
-            timeout: 30000
-        }, function (error, response, body) {
+    var promise = new Promise(function (resolve, reject) {
+        needle.request('get', url, qs, { 'username': username, 'password': password, timeout: 30000 }, function (error, response, body) {
             if (!error && response.statusCode === 200) {
                 var j = JSON.parse(body);
                 resolve(j);


### PR DESCRIPTION
Related to https://github.com/apache/incubator-openwhisk-runtime-nodejs/issues/142

currently these three actions(`github/webhook`, `slack/post`, `weather/forcast`) will be failed bacause of package `request` is not installed in the default nodejs runtime image.

So I think use `needle` maybe better because of it is available in all the node runtimes and doesn't need to install extra packages in docker images